### PR TITLE
Updates for PHP8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "irap/logging": "2.0.*"
+        "irap/logging": "2.1.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "irap/logging": "2.1.*"
+        "irap/logging": "dev-php8.4"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "irap/logging": "dev-php8.4"
+        "irap/logging": "2.2.*"
     },
     "autoload": {
         "psr-4": {

--- a/src/ErrorLogger.php
+++ b/src/ErrorLogger.php
@@ -32,7 +32,6 @@ class ErrorLogger
             (
                    $logError == E_NOTICE
                 || $logError == E_USER_NOTICE
-                || $logError == E_STRICT
                 || $logError == E_DEPRECATED
                 || $logError == E_USER_DEPRECATED
             )


### PR DESCRIPTION
Removed deprecated E_STRICT error level constant from ErrorLogger.php class.

Updated dependency: irap/logger to v2.2.*